### PR TITLE
fix for import error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-from arangodb import get_version
 
 setup(
     name='ArangoPy',


### PR DESCRIPTION
Hi,

Just a trivial fix for those who make use of the setup.py file. It looks like the get_version function was removed in 7a422467 and this hasn't been required since 403b197c.

Cheers!
